### PR TITLE
DockerイメージをCIでビルドできるようにする

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,8 @@ permissions:
   packages: write
 
 env:
+  ARM64_TMP_TAG: arm64-tmp-${{ github.run_id }}-${{ github.run_attempt }}
+  GHCR_IMAGE: ghcr.io/jj1guj/jiskey
   REGISTRY_IMAGE: jj1guj/jiskey
 
 jobs:
@@ -106,20 +108,20 @@ jobs:
             type=raw,value=test,enable=${{ github.event_name == 'workflow_dispatch' }}
             type=raw,value=latest,enable=${{ github.event_name == 'push' && needs.decide_latest.outputs.is_latest == 'true' }}
       - name: Log in to Docker Hub
-        if: ${{ !(github.event_name == 'workflow_dispatch' && matrix.platform == 'linux/arm64') }}
+        if: ${{ matrix.platform == 'linux/amd64' }}
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Log in to GHCR (arm64 experiment)
-        if: ${{ github.event_name == 'workflow_dispatch' && matrix.platform == 'linux/arm64' }}
+      - name: Log in to GHCR (arm64 staging)
+        if: ${{ matrix.platform == 'linux/arm64' }}
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push to Docker Hub
-        if: ${{ !(github.event_name == 'workflow_dispatch' && matrix.platform == 'linux/arm64') }}
+        if: ${{ matrix.platform == 'linux/amd64' }}
         id: build
         uses: docker/build-push-action@v7
         with:
@@ -131,31 +133,64 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-      - name: Build and Push to GHCR (arm64 experiment)
-        if: ${{ github.event_name == 'workflow_dispatch' && matrix.platform == 'linux/arm64' }}
+      - name: Build and Push to GHCR (arm64 staging)
+        if: ${{ matrix.platform == 'linux/arm64' }}
         uses: docker/build-push-action@v7
         with:
           context: .
           push: true
           platforms: linux/arm64
           provenance: false
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          tags: ghcr.io/jj1guj/jiskey:test
+          tags: ${{ env.GHCR_IMAGE }}:${{ env.ARM64_TMP_TAG }}
       - name: Export digest
-        if: ${{ !(github.event_name == 'workflow_dispatch' && matrix.platform == 'linux/arm64') }}
+        if: ${{ matrix.platform == 'linux/amd64' }}
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
       - name: Upload digest
-        if: ${{ !(github.event_name == 'workflow_dispatch' && matrix.platform == 'linux/arm64') }}
+        if: ${{ matrix.platform == 'linux/amd64' }}
         uses: actions/upload-artifact@v6
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
+
+  cleanup-arm64-tmp:
+    runs-on: ubuntu-latest
+    needs:
+      - merge
+    if: ${{ always() }}
+    steps:
+      - name: Delete temporary GHCR image
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Looking for GHCR temporary tag: ${{ env.ARM64_TMP_TAG }}"
+
+          version_id="$({
+            gh api \
+              "/users/${{ github.repository_owner }}/packages/container/jiskey/versions" \
+              --paginate \
+              --jq ".[] | select(any(.metadata.container.tags[]?; . == \"${{ env.ARM64_TMP_TAG }}\")) | .id"
+          } | head -n1)"
+
+          if [ -z "$version_id" ]; then
+            echo "No GHCR package version found for ${{ env.ARM64_TMP_TAG }}"
+            exit 0
+          fi
+
+          echo "Deleting GHCR package version id: $version_id"
+
+          gh api \
+            -X DELETE \
+            "/users/${{ github.repository_owner }}/packages/container/jiskey/versions/$version_id"
+
+          echo "Deleted GHCR temporary tag: ${{ env.ARM64_TMP_TAG }}"
 
   merge:
     runs-on: ubuntu-latest
@@ -185,11 +220,18 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *) \
+            "${{ env.GHCR_IMAGE }}:${{ env.ARM64_TMP_TAG }}"
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,25 +1,71 @@
-name: Publish Docker image
+name: Publish jiskey Docker image
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'jiskey_*'
   workflow_dispatch:
 
 env:
-  REGISTRY_IMAGE: misskey/misskey
-  TAGS: |
-    type=edge
-    type=ref,event=pr
-    type=ref,event=branch
-    type=semver,pattern={{version}}
-    type=semver,pattern={{major}}.{{minor}}
-    type=semver,pattern={{major}}
+  REGISTRY_IMAGE: jj1guj/jiskey
 
 jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Verify tag commit is on master
+        run: |
+          git fetch origin master --no-tags
+          TAG_COMMIT="$(git rev-list -n 1 "$GITHUB_REF")"
+          git merge-base --is-ancestor "$TAG_COMMIT" origin/master
+
+  decide_latest:
+    runs-on: ubuntu-latest
+    outputs:
+      is_latest: ${{ steps.check.outputs.is_latest }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Decide whether this tag should update latest
+        id: check
+        run: |
+          git fetch --tags --force
+
+          current="${GITHUB_REF_NAME#jiskey_}"
+
+          # 数値バージョンのみ latest 判定対象
+          if ! echo "$current" | grep -Eq '^[0-9]+(\.[0-9]+)*$'; then
+            echo "is_latest=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          max_version="$(
+            git tag -l 'jiskey_*' \
+              | sed 's/^jiskey_//' \
+              | grep -E '^[0-9]+(\.[0-9]+)*$' \
+              | sort -V \
+              | tail -n1
+          )"
+
+          if [ "$current" = "$max_version" ]; then
+            echo "is_latest=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_latest=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # see https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
   build:
     name: Build
     runs-on: ubuntu-latest
+    needs:
+      - guard
+      - decide_latest
     strategy:
       fail-fast: false
       matrix:
@@ -40,7 +86,9 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
-          tags: ${{ env.TAGS }}
+          tags: |
+            type=match,pattern=^jiskey_([0-9]+(\.[0-9]+)*)$,group=1
+            type=raw,value=latest,enable=${{ needs.decide_latest.outputs.is_latest == 'true' }}
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -75,6 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+      - decide_latest
     steps:
       - name: Download digests
         uses: actions/download-artifact@v7
@@ -89,7 +138,9 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
-          tags: ${{ env.TAGS }}
+          tags: |
+            type=match,pattern=^jiskey_([0-9]+(\.[0-9]+)*)$,group=1
+            type=raw,value=latest,enable=${{ needs.decide_latest.outputs.is_latest == 'true' }}
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -71,16 +71,18 @@ jobs:
   # see https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
     needs:
       - guard
       - decide_latest
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+        include:
+          - platform: linux/amd64
+            runs-on: ubuntu-latest
+          - platform: linux/arm64
+            runs-on: [self-hosted, Linux, ARM64]
     steps:
       - name: Prepare
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - name: Skip guard for workflow_dispatch
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: echo "Skipping tag ancestry check for workflow_dispatch"
       - name: Verify tag commit is on master
+        if: ${{ github.event_name == 'push' }}
         run: |
           git fetch origin master --no-tags
           TAG_COMMIT="$(git rev-list -n 1 "$GITHUB_REF")"
@@ -35,6 +39,11 @@ jobs:
       - name: Decide whether this tag should update latest
         id: check
         run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "is_latest=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           git fetch --tags --force
 
           current="${GITHUB_REF_NAME#jiskey_}"
@@ -87,8 +96,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
-            type=match,pattern=^jiskey_([0-9]+(\.[0-9]+)*)$,group=1
-            type=raw,value=latest,enable=${{ needs.decide_latest.outputs.is_latest == 'true' }}
+            type=match,pattern=^jiskey_([0-9]+(\.[0-9]+)*)$,group=1,enable=${{ github.event_name == 'push' }}
+            type=raw,value=test,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && needs.decide_latest.outputs.is_latest == 'true' }}
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -139,8 +149,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
-            type=match,pattern=^jiskey_([0-9]+(\.[0-9]+)*)$,group=1
-            type=raw,value=latest,enable=${{ needs.decide_latest.outputs.is_latest == 'true' }}
+            type=match,pattern=^jiskey_([0-9]+(\.[0-9]+)*)$,group=1,enable=${{ github.event_name == 'push' }}
+            type=raw,value=test,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && needs.decide_latest.outputs.is_latest == 'true' }}
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,88 +1,31 @@
-name: Publish jiskey Docker image
+name: Publish Docker image
 
 on:
-  push:
-    tags:
-      - 'jiskey_*'
+  release:
+    types: [published]
   workflow_dispatch:
 
 env:
-  REGISTRY_IMAGE: jj1guj/jiskey
+  REGISTRY_IMAGE: misskey/misskey
+  TAGS: |
+    type=edge
+    type=ref,event=pr
+    type=ref,event=branch
+    type=semver,pattern={{version}}
+    type=semver,pattern={{major}}.{{minor}}
+    type=semver,pattern={{major}}
 
 jobs:
-  guard:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - name: Skip guard for workflow_dispatch
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: echo "Skipping tag ancestry check for workflow_dispatch"
-      - name: Verify tag commit is on master
-        if: ${{ github.event_name == 'push' }}
-        run: |
-          git fetch origin master --no-tags
-          TAG_COMMIT="$(git rev-list -n 1 "$GITHUB_REF")"
-          git merge-base --is-ancestor "$TAG_COMMIT" origin/master
-
-  decide_latest:
-    runs-on: ubuntu-latest
-    outputs:
-      is_latest: ${{ steps.check.outputs.is_latest }}
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - name: Decide whether this tag should update latest
-        id: check
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "is_latest=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          git fetch --tags --force
-
-          current="${GITHUB_REF_NAME#jiskey_}"
-
-          # 数値バージョンのみ latest 判定対象
-          if ! echo "$current" | grep -Eq '^[0-9]+(\.[0-9]+)*$'; then
-            echo "is_latest=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          max_version="$(
-            git tag -l 'jiskey_*' \
-              | sed 's/^jiskey_//' \
-              | grep -E '^[0-9]+(\.[0-9]+)*$' \
-              | sort -V \
-              | tail -n1
-          )"
-
-          if [ "$current" = "$max_version" ]; then
-            echo "is_latest=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "is_latest=false" >> "$GITHUB_OUTPUT"
-          fi
-
   # see https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
   build:
     name: Build
-    runs-on: ${{ matrix.runs-on }}
-    needs:
-      - guard
-      - decide_latest
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - platform: linux/amd64
-            runs-on: ubuntu-latest
-          - platform: linux/arm64
-            runs-on: ubuntu-24.04-arm
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
       - name: Prepare
         run: |
@@ -91,24 +34,21 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@v3
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
-          tags: |
-            type=match,pattern=^jiskey_([0-9]+(\.[0-9]+)*)$,group=1,enable=${{ github.event_name == 'push' }}
-            type=raw,value=test,enable=${{ github.event_name == 'workflow_dispatch' }}
-            type=raw,value=latest,enable=${{ github.event_name == 'push' && needs.decide_latest.outputs.is_latest == 'true' }}
+          tags: ${{ env.TAGS }}
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and Push to Docker Hub
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true
@@ -135,7 +75,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
-      - decide_latest
     steps:
       - name: Download digests
         uses: actions/download-artifact@v7
@@ -144,18 +83,15 @@ jobs:
           pattern: digests-*
           merge-multiple: true
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@v3
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
-          tags: |
-            type=match,pattern=^jiskey_([0-9]+(\.[0-9]+)*)$,group=1,enable=${{ github.event_name == 'push' }}
-            type=raw,value=test,enable=${{ github.event_name == 'workflow_dispatch' }}
-            type=raw,value=latest,enable=${{ github.event_name == 'push' && needs.decide_latest.outputs.is_latest == 'true' }}
+          tags: ${{ env.TAGS }}
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,10 @@ on:
       - 'jiskey_*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   REGISTRY_IMAGE: jj1guj/jiskey
 
@@ -102,11 +106,20 @@ jobs:
             type=raw,value=test,enable=${{ github.event_name == 'workflow_dispatch' }}
             type=raw,value=latest,enable=${{ github.event_name == 'push' && needs.decide_latest.outputs.is_latest == 'true' }}
       - name: Log in to Docker Hub
+        if: ${{ !(github.event_name == 'workflow_dispatch' && matrix.platform == 'linux/arm64') }}
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Log in to GHCR (arm64 experiment)
+        if: ${{ github.event_name == 'workflow_dispatch' && matrix.platform == 'linux/arm64' }}
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push to Docker Hub
+        if: ${{ !(github.event_name == 'workflow_dispatch' && matrix.platform == 'linux/arm64') }}
         id: build
         uses: docker/build-push-action@v7
         with:
@@ -118,12 +131,25 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Build and Push to GHCR (arm64 experiment)
+        if: ${{ github.event_name == 'workflow_dispatch' && matrix.platform == 'linux/arm64' }}
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          platforms: linux/arm64
+          provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ghcr.io/jj1guj/jiskey:test
       - name: Export digest
+        if: ${{ !(github.event_name == 'workflow_dispatch' && matrix.platform == 'linux/arm64') }}
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
       - name: Upload digest
+        if: ${{ !(github.event_name == 'workflow_dispatch' && matrix.platform == 'linux/arm64') }}
         uses: actions/upload-artifact@v6
         with:
           name: digests-${{ env.PLATFORM_PAIR }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -131,7 +131,7 @@ jobs:
           provenance: false
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
       - name: Build and Push to GHCR (arm64 staging)
         if: ${{ matrix.platform == 'linux/arm64' }}
@@ -143,7 +143,7 @@ jobs:
           provenance: false
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min
           tags: ${{ env.GHCR_IMAGE }}:${{ env.ARM64_TMP_TAG }}
       - name: Export digest
         if: ${{ matrix.platform == 'linux/amd64' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -71,16 +71,18 @@ jobs:
   # see https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
     needs:
       - guard
       - decide_latest
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+        include:
+          - platform: linux/amd64
+            runs-on: ubuntu-latest
+          - platform: linux/arm64
+            runs-on: ubuntu-24.04-arm
     steps:
       - name: Prepare
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -89,10 +89,10 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
@@ -100,13 +100,13 @@ jobs:
             type=raw,value=test,enable=${{ github.event_name == 'workflow_dispatch' }}
             type=raw,value=latest,enable=${{ github.event_name == 'push' && needs.decide_latest.outputs.is_latest == 'true' }}
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and Push to Docker Hub
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -142,10 +142,10 @@ jobs:
           pattern: digests-*
           merge-multiple: true
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
@@ -153,7 +153,7 @@ jobs:
             type=raw,value=test,enable=${{ github.event_name == 'workflow_dispatch' }}
             type=raw,value=latest,enable=${{ github.event_name == 'push' && needs.decide_latest.outputs.is_latest == 'true' }}
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,13 +6,7 @@ on:
       - 'jiskey_*'
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: write
-
 env:
-  ARM64_TMP_TAG: arm64-tmp-${{ github.run_id }}-${{ github.run_attempt }}
-  GHCR_IMAGE: ghcr.io/jj1guj/jiskey
   REGISTRY_IMAGE: jj1guj/jiskey
 
 jobs:
@@ -77,18 +71,16 @@ jobs:
   # see https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
   build:
     name: Build
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ubuntu-latest
     needs:
       - guard
       - decide_latest
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - platform: linux/amd64
-            runs-on: ubuntu-latest
-          - platform: linux/arm64
-            runs-on: [self-hosted, Linux, ARM64]
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
       - name: Prepare
         run: |
@@ -108,20 +100,11 @@ jobs:
             type=raw,value=test,enable=${{ github.event_name == 'workflow_dispatch' }}
             type=raw,value=latest,enable=${{ github.event_name == 'push' && needs.decide_latest.outputs.is_latest == 'true' }}
       - name: Log in to Docker Hub
-        if: ${{ matrix.platform == 'linux/amd64' }}
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Log in to GHCR (arm64 staging)
-        if: ${{ matrix.platform == 'linux/arm64' }}
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push to Docker Hub
-        if: ${{ matrix.platform == 'linux/amd64' }}
         id: build
         uses: docker/build-push-action@v7
         with:
@@ -131,66 +114,20 @@ jobs:
           provenance: false
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=min
+          cache-to: type=gha,mode=max
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-      - name: Build and Push to GHCR (arm64 staging)
-        if: ${{ matrix.platform == 'linux/arm64' }}
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          push: true
-          platforms: linux/arm64
-          provenance: false
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
-          tags: ${{ env.GHCR_IMAGE }}:${{ env.ARM64_TMP_TAG }}
       - name: Export digest
-        if: ${{ matrix.platform == 'linux/amd64' }}
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
       - name: Upload digest
-        if: ${{ matrix.platform == 'linux/amd64' }}
         uses: actions/upload-artifact@v6
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
-
-  cleanup-arm64-tmp:
-    runs-on: ubuntu-latest
-    needs:
-      - merge
-    if: ${{ always() }}
-    steps:
-      - name: Delete temporary GHCR image
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "Looking for GHCR temporary tag: ${{ env.ARM64_TMP_TAG }}"
-
-          version_id="$({
-            gh api \
-              "/users/${{ github.repository_owner }}/packages/container/jiskey/versions" \
-              --paginate \
-              --jq ".[] | select(any(.metadata.container.tags[]?; . == \"${{ env.ARM64_TMP_TAG }}\")) | .id"
-          } | head -n1)"
-
-          if [ -z "$version_id" ]; then
-            echo "No GHCR package version found for ${{ env.ARM64_TMP_TAG }}"
-            exit 0
-          fi
-
-          echo "Deleting GHCR package version id: $version_id"
-
-          gh api \
-            -X DELETE \
-            "/users/${{ github.repository_owner }}/packages/container/jiskey/versions/$version_id"
-
-          echo "Deleted GHCR temporary tag: ${{ env.ARM64_TMP_TAG }}"
 
   merge:
     runs-on: ubuntu-latest
@@ -220,18 +157,11 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Login to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *) \
-            "${{ env.GHCR_IMAGE }}:${{ env.ARM64_TMP_TAG }}"
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/jiskey_docker.yml
+++ b/.github/workflows/jiskey_docker.yml
@@ -11,6 +11,8 @@ permissions:
   packages: write
 
 env:
+  ARM64_TMP_TAG: arm64-tmp-${{ github.run_id }}-${{ github.run_attempt }}
+  GHCR_IMAGE: ghcr.io/jj1guj/jiskey
   REGISTRY_IMAGE: jj1guj/jiskey
 
 jobs:
@@ -106,20 +108,20 @@ jobs:
             type=raw,value=test,enable=${{ github.event_name == 'workflow_dispatch' }}
             type=raw,value=latest,enable=${{ github.event_name == 'push' && needs.decide_latest.outputs.is_latest == 'true' }}
       - name: Log in to Docker Hub
-        if: ${{ !(github.event_name == 'workflow_dispatch' && matrix.platform == 'linux/arm64') }}
+        if: ${{ matrix.platform == 'linux/amd64' }}
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Log in to GHCR (arm64 experiment)
-        if: ${{ github.event_name == 'workflow_dispatch' && matrix.platform == 'linux/arm64' }}
+      - name: Log in to GHCR (arm64 staging)
+        if: ${{ matrix.platform == 'linux/arm64' }}
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push to Docker Hub
-        if: ${{ !(github.event_name == 'workflow_dispatch' && matrix.platform == 'linux/arm64') }}
+        if: ${{ matrix.platform == 'linux/amd64' }}
         id: build
         uses: docker/build-push-action@v7
         with:
@@ -131,31 +133,64 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-      - name: Build and Push to GHCR (arm64 experiment)
-        if: ${{ github.event_name == 'workflow_dispatch' && matrix.platform == 'linux/arm64' }}
+      - name: Build and Push to GHCR (arm64 staging)
+        if: ${{ matrix.platform == 'linux/arm64' }}
         uses: docker/build-push-action@v7
         with:
           context: .
           push: true
           platforms: linux/arm64
           provenance: false
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          tags: ghcr.io/jj1guj/jiskey:test
+          tags: ${{ env.GHCR_IMAGE }}:${{ env.ARM64_TMP_TAG }}
       - name: Export digest
-        if: ${{ !(github.event_name == 'workflow_dispatch' && matrix.platform == 'linux/arm64') }}
+        if: ${{ matrix.platform == 'linux/amd64' }}
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
       - name: Upload digest
-        if: ${{ !(github.event_name == 'workflow_dispatch' && matrix.platform == 'linux/arm64') }}
+        if: ${{ matrix.platform == 'linux/amd64' }}
         uses: actions/upload-artifact@v6
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
+
+  cleanup-arm64-tmp:
+    runs-on: ubuntu-latest
+    needs:
+      - merge
+    if: ${{ always() }}
+    steps:
+      - name: Delete temporary GHCR image
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Looking for GHCR temporary tag: ${{ env.ARM64_TMP_TAG }}"
+
+          version_id="$({
+            gh api \
+              "/users/${{ github.repository_owner }}/packages/container/jiskey/versions" \
+              --paginate \
+              --jq ".[] | select(any(.metadata.container.tags[]?; . == \"${{ env.ARM64_TMP_TAG }}\")) | .id"
+          } | head -n1)"
+
+          if [ -z "$version_id" ]; then
+            echo "No GHCR package version found for ${{ env.ARM64_TMP_TAG }}"
+            exit 0
+          fi
+
+          echo "Deleting GHCR package version id: $version_id"
+
+          gh api \
+            -X DELETE \
+            "/users/${{ github.repository_owner }}/packages/container/jiskey/versions/$version_id"
+
+          echo "Deleted GHCR temporary tag: ${{ env.ARM64_TMP_TAG }}"
 
   merge:
     runs-on: ubuntu-latest
@@ -185,11 +220,18 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *) \
+            "${{ env.GHCR_IMAGE }}:${{ env.ARM64_TMP_TAG }}"
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/jiskey_docker.yml
+++ b/.github/workflows/jiskey_docker.yml
@@ -1,0 +1,105 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+env:
+  REGISTRY_IMAGE: misskey/misskey
+  TAGS: |
+    type=edge
+    type=ref,event=pr
+    type=ref,event=branch
+    type=semver,pattern={{version}}
+    type=semver,pattern={{major}}.{{minor}}
+    type=semver,pattern={{major}}
+
+jobs:
+  # see https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    steps:
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+      - name: Check out the repo
+        uses: actions/checkout@v6.0.2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: ${{ env.TAGS }}
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and Push to Docker Hub
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: ${{ matrix.platform }}
+          provenance: false
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v6
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v7
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: ${{ env.TAGS }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/jiskey_docker.yml
+++ b/.github/workflows/jiskey_docker.yml
@@ -71,16 +71,18 @@ jobs:
   # see https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
     needs:
       - guard
       - decide_latest
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+        include:
+          - platform: linux/amd64
+            runs-on: ubuntu-latest
+          - platform: linux/arm64
+            runs-on: [self-hosted, Linux, ARM64]
     steps:
       - name: Prepare
         run: |

--- a/.github/workflows/jiskey_docker.yml
+++ b/.github/workflows/jiskey_docker.yml
@@ -17,7 +17,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - name: Skip guard for workflow_dispatch
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: echo "Skipping tag ancestry check for workflow_dispatch"
       - name: Verify tag commit is on master
+        if: ${{ github.event_name == 'push' }}
         run: |
           git fetch origin master --no-tags
           TAG_COMMIT="$(git rev-list -n 1 "$GITHUB_REF")"
@@ -35,6 +39,11 @@ jobs:
       - name: Decide whether this tag should update latest
         id: check
         run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "is_latest=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           git fetch --tags --force
 
           current="${GITHUB_REF_NAME#jiskey_}"
@@ -87,8 +96,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
-            type=match,pattern=^jiskey_([0-9]+(\.[0-9]+)*)$,group=1
-            type=raw,value=latest,enable=${{ needs.decide_latest.outputs.is_latest == 'true' }}
+            type=match,pattern=^jiskey_([0-9]+(\.[0-9]+)*)$,group=1,enable=${{ github.event_name == 'push' }}
+            type=raw,value=test,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && needs.decide_latest.outputs.is_latest == 'true' }}
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -139,8 +149,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
-            type=match,pattern=^jiskey_([0-9]+(\.[0-9]+)*)$,group=1
-            type=raw,value=latest,enable=${{ needs.decide_latest.outputs.is_latest == 'true' }}
+            type=match,pattern=^jiskey_([0-9]+(\.[0-9]+)*)$,group=1,enable=${{ github.event_name == 'push' }}
+            type=raw,value=test,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && needs.decide_latest.outputs.is_latest == 'true' }}
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/jiskey_docker.yml
+++ b/.github/workflows/jiskey_docker.yml
@@ -6,6 +6,10 @@ on:
       - 'jiskey_*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   REGISTRY_IMAGE: jj1guj/jiskey
 
@@ -102,11 +106,20 @@ jobs:
             type=raw,value=test,enable=${{ github.event_name == 'workflow_dispatch' }}
             type=raw,value=latest,enable=${{ github.event_name == 'push' && needs.decide_latest.outputs.is_latest == 'true' }}
       - name: Log in to Docker Hub
+        if: ${{ !(github.event_name == 'workflow_dispatch' && matrix.platform == 'linux/arm64') }}
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Log in to GHCR (arm64 experiment)
+        if: ${{ github.event_name == 'workflow_dispatch' && matrix.platform == 'linux/arm64' }}
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push to Docker Hub
+        if: ${{ !(github.event_name == 'workflow_dispatch' && matrix.platform == 'linux/arm64') }}
         id: build
         uses: docker/build-push-action@v7
         with:
@@ -118,12 +131,25 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Build and Push to GHCR (arm64 experiment)
+        if: ${{ github.event_name == 'workflow_dispatch' && matrix.platform == 'linux/arm64' }}
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          platforms: linux/arm64
+          provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ghcr.io/jj1guj/jiskey:test
       - name: Export digest
+        if: ${{ !(github.event_name == 'workflow_dispatch' && matrix.platform == 'linux/arm64') }}
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
       - name: Upload digest
+        if: ${{ !(github.event_name == 'workflow_dispatch' && matrix.platform == 'linux/arm64') }}
         uses: actions/upload-artifact@v6
         with:
           name: digests-${{ env.PLATFORM_PAIR }}

--- a/.github/workflows/jiskey_docker.yml
+++ b/.github/workflows/jiskey_docker.yml
@@ -131,7 +131,7 @@ jobs:
           provenance: false
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
       - name: Build and Push to GHCR (arm64 staging)
         if: ${{ matrix.platform == 'linux/arm64' }}
@@ -143,7 +143,7 @@ jobs:
           provenance: false
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min
           tags: ${{ env.GHCR_IMAGE }}:${{ env.ARM64_TMP_TAG }}
       - name: Export digest
         if: ${{ matrix.platform == 'linux/amd64' }}

--- a/.github/workflows/jiskey_docker.yml
+++ b/.github/workflows/jiskey_docker.yml
@@ -8,14 +8,6 @@ on:
 
 env:
   REGISTRY_IMAGE: jj1guj/jiskey
-  TAGS: |
-    type=edge
-    type=ref,event=pr
-    type=ref,event=branch
-    type=ref,event=tag
-    type=semver,pattern={{version}}
-    type=semver,pattern={{major}}.{{minor}}
-    type=semver,pattern={{major}}
 
 jobs:
   guard:
@@ -31,12 +23,49 @@ jobs:
           TAG_COMMIT="$(git rev-list -n 1 "$GITHUB_REF")"
           git merge-base --is-ancestor "$TAG_COMMIT" origin/master
 
+  decide_latest:
+    runs-on: ubuntu-latest
+    outputs:
+      is_latest: ${{ steps.check.outputs.is_latest }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Decide whether this tag should update latest
+        id: check
+        run: |
+          git fetch --tags --force
+
+          current="${GITHUB_REF_NAME#jiskey_}"
+
+          # 数値バージョンのみ latest 判定対象
+          if ! echo "$current" | grep -Eq '^[0-9]+(\.[0-9]+)*$'; then
+            echo "is_latest=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          max_version="$(
+            git tag -l 'jiskey_*' \
+              | sed 's/^jiskey_//' \
+              | grep -E '^[0-9]+(\.[0-9]+)*$' \
+              | sort -V \
+              | tail -n1
+          )"
+
+          if [ "$current" = "$max_version" ]; then
+            echo "is_latest=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_latest=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # see https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
   build:
     name: Build
     runs-on: ubuntu-latest
     needs:
       - guard
+      - decide_latest
     strategy:
       fail-fast: false
       matrix:
@@ -57,7 +86,9 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
-          tags: ${{ env.TAGS }}
+          tags: |
+            type=match,pattern=^jiskey_([0-9]+(\.[0-9]+)*)$,group=1
+            type=raw,value=latest,enable=${{ needs.decide_latest.outputs.is_latest == 'true' }}
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -92,6 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+      - decide_latest
     steps:
       - name: Download digests
         uses: actions/download-artifact@v7
@@ -106,7 +138,9 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
-          tags: ${{ env.TAGS }}
+          tags: |
+            type=match,pattern=^jiskey_([0-9]+(\.[0-9]+)*)$,group=1
+            type=raw,value=latest,enable=${{ needs.decide_latest.outputs.is_latest == 'true' }}
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/jiskey_docker.yml
+++ b/.github/workflows/jiskey_docker.yml
@@ -1,25 +1,42 @@
-name: Publish Docker image
+name: Publish jiskey Docker image
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'jiskey_*'
   workflow_dispatch:
 
 env:
-  REGISTRY_IMAGE: misskey/misskey
+  REGISTRY_IMAGE: jj1guj/jiskey
   TAGS: |
     type=edge
     type=ref,event=pr
     type=ref,event=branch
+    type=ref,event=tag
     type=semver,pattern={{version}}
     type=semver,pattern={{major}}.{{minor}}
     type=semver,pattern={{major}}
 
 jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Verify tag commit is on master
+        run: |
+          git fetch origin master --no-tags
+          TAG_COMMIT="$(git rev-list -n 1 "$GITHUB_REF")"
+          git merge-base --is-ancestor "$TAG_COMMIT" origin/master
+
   # see https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
   build:
     name: Build
     runs-on: ubuntu-latest
+    needs:
+      - guard
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/jiskey_docker.yml
+++ b/.github/workflows/jiskey_docker.yml
@@ -71,16 +71,18 @@ jobs:
   # see https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
     needs:
       - guard
       - decide_latest
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+        include:
+          - platform: linux/amd64
+            runs-on: ubuntu-latest
+          - platform: linux/arm64
+            runs-on: ubuntu-24.04-arm
     steps:
       - name: Prepare
         run: |

--- a/.github/workflows/jiskey_docker.yml
+++ b/.github/workflows/jiskey_docker.yml
@@ -89,10 +89,10 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
@@ -100,13 +100,13 @@ jobs:
             type=raw,value=test,enable=${{ github.event_name == 'workflow_dispatch' }}
             type=raw,value=latest,enable=${{ github.event_name == 'push' && needs.decide_latest.outputs.is_latest == 'true' }}
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and Push to Docker Hub
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -142,10 +142,10 @@ jobs:
           pattern: digests-*
           merge-multiple: true
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
@@ -153,7 +153,7 @@ jobs:
             type=raw,value=test,enable=${{ github.event_name == 'workflow_dispatch' }}
             type=raw,value=latest,enable=${{ github.event_name == 'push' && needs.decide_latest.outputs.is_latest == 'true' }}
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/jiskey_docker.yml
+++ b/.github/workflows/jiskey_docker.yml
@@ -6,13 +6,7 @@ on:
       - 'jiskey_*'
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: write
-
 env:
-  ARM64_TMP_TAG: arm64-tmp-${{ github.run_id }}-${{ github.run_attempt }}
-  GHCR_IMAGE: ghcr.io/jj1guj/jiskey
   REGISTRY_IMAGE: jj1guj/jiskey
 
 jobs:
@@ -77,18 +71,16 @@ jobs:
   # see https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
   build:
     name: Build
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ubuntu-latest
     needs:
       - guard
       - decide_latest
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - platform: linux/amd64
-            runs-on: ubuntu-latest
-          - platform: linux/arm64
-            runs-on: [self-hosted, Linux, ARM64]
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
       - name: Prepare
         run: |
@@ -108,20 +100,11 @@ jobs:
             type=raw,value=test,enable=${{ github.event_name == 'workflow_dispatch' }}
             type=raw,value=latest,enable=${{ github.event_name == 'push' && needs.decide_latest.outputs.is_latest == 'true' }}
       - name: Log in to Docker Hub
-        if: ${{ matrix.platform == 'linux/amd64' }}
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Log in to GHCR (arm64 staging)
-        if: ${{ matrix.platform == 'linux/arm64' }}
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push to Docker Hub
-        if: ${{ matrix.platform == 'linux/amd64' }}
         id: build
         uses: docker/build-push-action@v7
         with:
@@ -131,66 +114,20 @@ jobs:
           provenance: false
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=min
+          cache-to: type=gha,mode=max
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-      - name: Build and Push to GHCR (arm64 staging)
-        if: ${{ matrix.platform == 'linux/arm64' }}
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          push: true
-          platforms: linux/arm64
-          provenance: false
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
-          tags: ${{ env.GHCR_IMAGE }}:${{ env.ARM64_TMP_TAG }}
       - name: Export digest
-        if: ${{ matrix.platform == 'linux/amd64' }}
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
       - name: Upload digest
-        if: ${{ matrix.platform == 'linux/amd64' }}
         uses: actions/upload-artifact@v6
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
-
-  cleanup-arm64-tmp:
-    runs-on: ubuntu-latest
-    needs:
-      - merge
-    if: ${{ always() }}
-    steps:
-      - name: Delete temporary GHCR image
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "Looking for GHCR temporary tag: ${{ env.ARM64_TMP_TAG }}"
-
-          version_id="$({
-            gh api \
-              "/users/${{ github.repository_owner }}/packages/container/jiskey/versions" \
-              --paginate \
-              --jq ".[] | select(any(.metadata.container.tags[]?; . == \"${{ env.ARM64_TMP_TAG }}\")) | .id"
-          } | head -n1)"
-
-          if [ -z "$version_id" ]; then
-            echo "No GHCR package version found for ${{ env.ARM64_TMP_TAG }}"
-            exit 0
-          fi
-
-          echo "Deleting GHCR package version id: $version_id"
-
-          gh api \
-            -X DELETE \
-            "/users/${{ github.repository_owner }}/packages/container/jiskey/versions/$version_id"
-
-          echo "Deleted GHCR temporary tag: ${{ env.ARM64_TMP_TAG }}"
 
   merge:
     runs-on: ubuntu-latest
@@ -220,18 +157,11 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Login to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *) \
-            "${{ env.GHCR_IMAGE }}:${{ env.ARM64_TMP_TAG }}"
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/jiskey_CHANGELOG.md
+++ b/jiskey_CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2026.4.0
+
+### Client
+- 
+
+### Server
+- 
+
+### Others
+- CIでDockerイメージをビルドするように
+	- docker pull jj1guj/jiskey:latest でpullできるように
+
 ## 2026.3.2
 
 ### Client


### PR DESCRIPTION
DockerイメージをCIでビルドできるようにした
ビルド済みのイメージは`docker pull jj1guj/jiskey:<tag>`でpullできるようにしてある
https://hub.docker.com/repository/docker/jj1guj/jiskey

CIが動作することも確認済み
https://github.com/jj1guj/jiskey/actions/runs/24408525109