### PR TITLE
loadRawImages有効時、リモート画像をタップしてからビューワーが開くまでに初回のみラグがある問題を修正

### DIFF
--- a/packages/frontend/src/components/MkLightbox.item.vue
+++ b/packages/frontend/src/components/MkLightbox.item.vue
@@ -702,7 +702,7 @@ function animateFromSourceToNeutral() {
 	});
 }
 
-watch(thumbnailContentLoaded, () => {
+watch([thumbnailContentLoaded, originalContentLoaded], () => {
 	animateFromSourceToNeutral();
 }, { once: true });
 


### PR DESCRIPTION
## What

ビューワー起動時のアニメーション実行処理のトリガーをサムネイル画像又はオリジナル画像のどちらかが早く読み込まれたときに発火するように修正しました。
これにより、loadRawImages有効時にリモート画像をタップしてからビューワーが開くまで、初回のみラグがある問題が直ります。

See also: https://github.com/jj1guj/jiskey/issues/162

## Why

loadRawImages有効時にリモート画像をタップすると以下の流れでメディアプロキシでのサムネイル画像生成が走り、その時間分だけラグが発生するようになっていたため

1. タイムラインは MkMediaImage の url computed により image.url(オリジナル画像)だけを読み込む。thumbnailUrl はタイムライン表示では一度もリクエストされない。
2. ビューワーを開くと、原寸はブラウザキャッシュ済みなので `originalContentLoaded` はほぼ即座に true になる。表示に必要なものは全部揃っている。
3. しかしアニメーションのトリガーはサムネイルのloadなので、ここで初めて thumbnailUrl へのリクエストが走る。
    - 初回はメディアプロキシがリモートから画像を取得し、オリジナル画像をサムネイル画像のstatic webpに変換する時間がまるごとラグとして現れる
    - 2回目以降はブラウザ側とメディアプロキシ側のキャッシュに乗るので即座にビューワーが開く
4. その間、ビューワーは背景が暗転したまま画像がタイムライン上の位置・サイズ(source transform)に張り付いて止まり、サムネイルが届いた瞬間にズームアニメーションが始まる。

## Additional info (optional)

### テスト観点

- loadRawImages有効時、未閲覧のリモート画像をタップした際、サムネイル画像(/proxy/static.webp?url=...)のリクエスト完了を待たずにオープンアニメーションが開始される
    - DevToolsのNetworkタブでスロットリング(Slow 3G等)をかけると、該当リクエストがpendingのままアニメーションが始まることを確認しやすい
- リモートの画像をタップしてビューワーを起動するときにラグが発生しない

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
